### PR TITLE
[FEATURE] Add cookieOption Object to be Usable in Template

### DIFF
--- a/Classes/ViewHelpers/MediaViewHelper.php
+++ b/Classes/ViewHelpers/MediaViewHelper.php
@@ -50,8 +50,6 @@ class MediaViewHelper extends CoreMediaViewHelper
         $media = parent::render();
 
         if ('<iframe' === substr($media, 0, 7)) {
-            $cookieConsentService = ObjectUtility::makeInstance(CookieConsentService::class);
-
             $cookieOption = 'media';
 
             if (1 === preg_match('/src=".*?\/\/(www\.)?(youtube|youtu\.be)/i', $media)) {
@@ -68,7 +66,7 @@ class MediaViewHelper extends CoreMediaViewHelper
                 [
                     'iframe' => htmlentities($media),
                     'cookieOption' => $cookieOption,
-                    'cookieOptionObject' => $cookieConsentService->getCookieOptionFromIdentifier($cookieOption),
+                    'cookieOptionObject' => $this->cookieConsentService->getCookieOptionFromIdentifier($cookieOption),
                     'datapolicyPageTypoLink' => $this->cookieConsentService->getDatapolicyPageTypoLink(),
                     'imprintPageTypoLink' => $this->cookieConsentService->getImprintPageTypoLink(),
                 ]

--- a/Classes/ViewHelpers/MediaViewHelper.php
+++ b/Classes/ViewHelpers/MediaViewHelper.php
@@ -50,6 +50,8 @@ class MediaViewHelper extends CoreMediaViewHelper
         $media = parent::render();
 
         if ('<iframe' === substr($media, 0, 7)) {
+            $cookieConsentService = ObjectUtility::makeInstance(CookieConsentService::class);
+
             $cookieOption = 'media';
 
             if (1 === preg_match('/src=".*?\/\/(www\.)?(youtube|youtu\.be)/i', $media)) {
@@ -66,6 +68,7 @@ class MediaViewHelper extends CoreMediaViewHelper
                 [
                     'iframe' => htmlentities($media),
                     'cookieOption' => $cookieOption,
+                    'cookieOptionObject' => $cookieConsentService->getCookieOptionFromIdentifier($cookieOption),
                     'datapolicyPageTypoLink' => $this->cookieConsentService->getDatapolicyPageTypoLink(),
                     'imprintPageTypoLink' => $this->cookieConsentService->getImprintPageTypoLink(),
                 ]


### PR DESCRIPTION
We had this in a custumer Request to use the specific Cookie Name in the Media Template.
As well as the Description which we can get from the CookieOption Object.

I chose to add this as an additional Parameter to keep it backwards compatible.