### PR TITLE
[TASK] compatibility with typo3/cms-composer-installers v4

### DIFF
--- a/Classes/Hook/RenderPreProcessHook.php
+++ b/Classes/Hook/RenderPreProcessHook.php
@@ -82,13 +82,13 @@ class RenderPreProcessHook
                 if (true === (bool)$settings['addJavaScript']) {
                     $pageRenderer->addJsFooterLibrary(
                         'cookie_consent',
-                        PathUtility::getAbsoluteWebPath('typo3conf/ext/mindshape_cookie_consent/Resources/Public/JavaScript/cookie_consent.js')
+                        PathUtility::getPublicResourceWebPath('EXT:mindshape_cookie_consent/Resources/Public/JavaScript/cookie_consent.js')
                     );
                 }
 
                 if (true === (bool)$settings['addStylesheet']) {
                     $pageRenderer->addCssFile(
-                        PathUtility::getAbsoluteWebPath('typo3conf/ext/mindshape_cookie_consent/Resources/Public/Stylesheet/cookie_consent.css')
+                        PathUtility::getPublicResourceWebPath('EXT:mindshape_cookie_consent/Resources/Public/Stylesheet/cookie_consent.css')
                     );
                 }
 


### PR DESCRIPTION
with typo3/cms-composer-installers v4 (TYPO3 v11 and v12) the hardcoded path typo3conf/ext is not working anymore. The correct path for public Resources has to be resolved.