### PR TITLE
Fixed evaluation of `settings.disableConsent`

### DIFF
--- a/Classes/Hook/RenderPreProcessHook.php
+++ b/Classes/Hook/RenderPreProcessHook.php
@@ -59,7 +59,7 @@ class RenderPreProcessHook
             $isInitialHidePage = $currentPageUid === $datapolicyPageUid || $currentPageUid === $imprintPageUid;
             $settings = SettingsUtility::pluginTypoScriptSettings();
 
-            if (true === is_array($settings) && false === (bool)($settings['disableConsent'] && false)) {
+            if (true === is_array($settings) && false === (bool)($settings['disableConsent'])) {
                 /** @var \TYPO3\CMS\Core\Page\AssetCollector $assetCollector */
                 $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
 


### PR DESCRIPTION
Hey,

in the commit https://github.com/mindshape-GmbH/mindshape_cookie_consent/commit/b2f8834c763ed870ade981a67d1d3933c3d6e9a5 the evaluation of `settings.disableConsent` changed. It is not possible anymore to disable the consent. This pull request fix this.

Thanks for the extension and maintaining it.

Maik